### PR TITLE
Fix typing comment spelling

### DIFF
--- a/lib/customTypes.d.ts
+++ b/lib/customTypes.d.ts
@@ -3,7 +3,7 @@ import { Locale } from "./i18n/locales";
 // Content Matrix:
 // [i][j] - each element represents entire component content
 // where:
-// i - value of content_type (proffessional vs personal)
+// i - value of content_type (professional vs personal)
 // j - value of read_time (short vs descriptive)
 
 export type ContentMatrix<T = React.ReactNode> = {


### PR DESCRIPTION
## Summary
- fix a spelling error in `lib/customTypes.d.ts`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852773cf3dc8331a48158b171a24641