### PR TITLE
Fix canonical URL handling for localized pages

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -44,20 +44,20 @@ export const generateMetadata: (props: {
   const metadata: Metadata = {
     title: t("title"),
     description: t("description"),
-    alternates: {
-      canonical: BASE_URL,
-      languages: Object.fromEntries(
-        locales.map((locale) => [locale, `${BASE_URL}/${locale}`])
-      ),
-    },
-    openGraph: {
-      title: t("title"),
-      description: t("description"),
-      url: BASE_URL,
-      siteName: DOMAIN_NAME,
-      type: "website",
-      locale,
-    },
+      alternates: {
+        canonical: `${BASE_URL}/${locale}`,
+        languages: Object.fromEntries(
+          locales.map((locale) => [locale, `${BASE_URL}/${locale}`])
+        ),
+      },
+      openGraph: {
+        title: t("title"),
+        description: t("description"),
+        url: `${BASE_URL}/${locale}`,
+        siteName: DOMAIN_NAME,
+        type: "website",
+        locale,
+      },
     icons: {
       icon: "./favicon.png",
     },
@@ -123,7 +123,7 @@ const LangLayout: React.FC<PropsWithChildren<RootLayoutProps>> = async ({
                 "Сева",
                 "Seva",
               ],
-              url: BASE_URL,
+              url: `${BASE_URL}/${locale}`,
               sameAs: [
                 LINKEDIN_URL,
                 GITHUB_PROFILE_URL,


### PR DESCRIPTION
## Summary
- ensure each locale has a unique canonical URL in metadata
- update Open Graph and structured data URLs to include locale

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527b255a788331ace3647403beceea